### PR TITLE
[POC] No field removal for messages annotated with persisted and its dependencies

### DIFF
--- a/testdata/child.proto
+++ b/testdata/child.proto
@@ -1,0 +1,8 @@
+syntax = "proto3";
+
+package child;
+
+message User {
+    int64 id = 1;
+
+}

--- a/testdata/test.proto
+++ b/testdata/test.proto
@@ -1,5 +1,13 @@
 syntax = "proto3";
+
+import "google/protobuf/descriptor.proto";
+import "testdata/child.proto";
+
 package dataset;
+
+extend google.protobuf.MessageOptions {
+  optional bool persisted = 51234;
+}
 
 message Channel {
   reserved 6, 8 to 11;
@@ -12,6 +20,13 @@ message Channel {
   message A { int32 id = 1; }
 
   A msg = 44;
+}
+
+message TestAnnotation {
+  option (persisted) = true;
+  int64 id = 1;
+  Channel channel = 2;
+  child.User user = 3;
 }
 
 message Display {
@@ -62,7 +77,3 @@ message PreviousRequest {
   }
 }
 
-service ChannelChanger {
-  rpc Next(stream NextRequest) returns (Channel);
-  rpc Previous(PreviousRequest) returns (stream Channel);
-}


### PR DESCRIPTION
This is a brute-force solution and it can be further optimized

This is a POC to check if there is any field removal for messages (and its dependencies) annotated with persisted.

For example, removing address_info or address will violate the rule. 
```
message User {
	option (persisted) = true;
 	AddressInfo address_info = 1 
}
message AddressInfo {
	string address = 1
} 
message PhoneInfo {
	String phone = 1
}

```